### PR TITLE
Stop GOV.UK PaaS deployments

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -51,10 +51,6 @@ jobs:
     needs: [ test ]
     concurrency: deploy-staging
     if: github.ref == 'refs/heads/main'
-    env:
-      ENVIRONMENT: staging
-      CF_USERNAME: ${{ secrets.GOV_PAAS_SERVICE_ACCOUNT_USERNAME }}
-      CF_PASSWORD: ${{ secrets.GOV_PAAS_SERVICE_ACCOUNT_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
       - uses: aws-actions/configure-aws-credentials@v1
@@ -62,11 +58,4 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DL_WEB }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DL_WEB }}
           aws-region: ${{ env.AWS_REGION }}
-      - name: install cloudfoundry cli
-        run: |
-          curl https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-          sudo apt update
-          sudo apt install -y cf7-cli
       - run: make docker-promote-candidate
-      - run: make cf-deploy

--- a/Makefile
+++ b/Makefile
@@ -70,18 +70,6 @@ endif
 docker-login-public:
 	aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
-cf-login:
-	cf api https://api.london.cloud.service.gov.uk
-	cf auth
-
-cf-deploy: cf-login
-ifeq (, $(ENVIRONMENT))
-	$(error "No environment specified via $$ENVIRONMENT, please pass as make argument")
-endif
-	cf target -o dluhc-digital-land -s $(ENVIRONMENT)
-	cf push $(ENVIRONMENT)-$(APPLICATION) --docker-image $(DOCKER_REPO)/$(APPLICATION):$(ENVIRONMENT)
-	cf run-task $(ENVIRONMENT)-$(APPLICATION) --command "cd /app && flask db upgrade" --name migrate --wait -k 2G -m 1G
-
 docker-dev-build:
 	docker-compose \
 		-f docker-compose.yml \


### PR DESCRIPTION
*What?*
No longer deploy to GOV.UK PaaS as part of the pipeline.

*Why?*
GOV.UK PaaS is decommissioning so we are aborting our move to it.

*How?*
Just deleted any reference to the deployment to GOV.UK PaaS. I've kept the build and test phases 